### PR TITLE
Added Print GetRequest in client.py

### DIFF
--- a/pygnmi/client.py
+++ b/pygnmi/client.py
@@ -194,6 +194,7 @@ class gNMIclient(object):
             gnmi_message_response = self.__stub.Get(gnmi_message_request, metadata=self.__metadata)
 
             if self.__to_print:
+                print(gnmi_message_request)
                 print(gnmi_message_response)
 
             if gnmi_message_response:


### PR DESCRIPTION
Added print of GetRequest for Debugging 

Test Logs 

```
`path {
  origin: "openconfig-platform"
  elem {
    name: "components"
  }
}
type: CONFIG
encoding: JSON_IETF

notification {
  timestamp: 1611158385899695603
  update {
    path {
      origin: "openconfig-platform"
      elem {
        name: "components"
      }
    }
    val {
      json_ietf_val: "{\"component\":[{\"name\":\"0/0-OpticalChannel0/0/0/0\",\"config\":{\"name\":\"0/0-OpticalChannel0/0/0/0\"},\"openconfig-terminal-device:optical-channel\":{\"config\":{\"target-output-power\":\"-500\",\"frequency\":196100000,\"line-port\":\"0/0-Optics0/0/0/0\",\"operational-mode\":4177}}},{\"name\":\"0/0-OpticalChannel0/0/0/1\",\"config\":{\"name\":\"0/0-OpticalChannel0/0/0/1\"},\"openconfig-terminal-device:optical-channel\":{\"config\":{\"target-output-power\":\"-500\",\"frequency\":196100000,\"line-port\":\"0/0-Optics0/0/0/1\",\"operational-mode\":4177}}},{\"name\":\"0/1-OpticalChannel0/1/0/0\",\"config\":{\"name\":\"0/1-OpticalChannel0/1/0/0\"},\"openconfig-terminal-device:optical-channel\":{\"config\":{\"target-output-power\":\"-500\",\"frequency\":196100000,\"line-port\":\"0/1-Optics0/1/0/0\",\"operational-mode\":1672}}},{\"name\":\"0/1-OpticalChannel0/1/0/1\",\"config\":{\"name\":\"0/1-OpticalChannel0/1/0/1\"},\"openconfig-terminal-device:optical-channel\":{\"config\":{\"target-output-power\":\"-500\",\"frequency\":196100000,\"line-port\":\"0/1-Optics0/1/0/1\",\"operational-mode\":1672}}},{\"name\":\"0/2-OpticalChannel0/2/0/0\",\"config\":{\"name\":\"0/2-OpticalChannel0/2/0/0\"},\"openconfig-terminal-device:optical-channel\":{\"config\":{\"target-output-power\":\"-500\",\"frequency\":191806000,\"line-port\":\"0/2-Optics0/2/0/0\",\"operational-mode\":4}}},{\"name\":\"0/2-OpticalChannel0/2/0/1\",\"config\":{\"name\":\"0/2-OpticalChannel0/2/0/1\"},\"openconfig-terminal-device:optical-channel\":{\"config\":{\"target-output-power\":\"-500\",\"frequency\":191806000,\"line-port\":\"0/2-Optics0/2/0/1\",\"operational-mode\":4}}},{\"name\":\"0/3-OpticalChannel0/3/0/0\",\"config\":{\"name\":\"0/3-OpticalChannel0/3/0/0\"},\"openconfig-terminal-device:optical-channel\":{\"config\":{\"target-output-power\":\"-500\",\"frequency\":186160000,\"line-port\":\"0/3-Optics0/3/0/0\",\"operational-mode\":1672}}},{\"name\":\"0/3-OpticalChannel0/3/0/1\",\"config\":{\"name\":\"0/3-OpticalChannel0/3/0/1\"},\"openconfig-terminal-device:optical-channel\":{\"config\":{\"target-output-power\":\"-500\",\"frequency\":186160000,\"line-port\":\"0/3-Optics0/3/0/1\",\"operational-mode\":1672}}}]}"
    }
  }
}
error {
}
`


```