### PR TITLE
Fix invalid escapes

### DIFF
--- a/pygnmi/arg_parser.py
+++ b/pygnmi/arg_parser.py
@@ -53,8 +53,8 @@ class NFData(object):
 
                 elif input_vars[ind] == '-t' or input_vars[ind] == '--target':
                     try:
-                        if re.match('\[.*\]', input_vars[ind + 1]):
-                            self.targets = re.sub('^\[([0-9a-f:]+?)\]:(\d+?)$', '\g<1> \g<2>', input_vars[ind + 1]).split(' ')
+                        if re.match(r'\[.*\]', input_vars[ind + 1]):
+                            self.targets = re.sub(r'^\[([0-9a-f:]+?)\]:(\d+?)$', r'\g<1> \g<2>', input_vars[ind + 1]).split(' ')
 
                         else:
                             self.targets = (str(input_vars[ind + 1].split(':')[0]), int(input_vars[ind + 1].split(':')[1]))

--- a/pygnmi/path_generator.py
+++ b/pygnmi/path_generator.py
@@ -14,14 +14,14 @@ def gnmi_path_generator(path_in_question: list):
 
     # Subtracting all the keys from the elements and storing them separately
     if path_in_question:
-        if re.match('.*?\[.+?=.+?\].*?', path_in_question):
-            split_list = re.findall('.*?\[.+?=.+?\].*?', path_in_question)
+        if re.match(r'.*?\[.+?=.+?\].*?', path_in_question):
+            split_list = re.findall(r'.*?\[.+?=.+?\].*?', path_in_question)
 
             for sle in split_list:
                 temp_non_modified += sle
-                temp_key, temp_value = re.sub('.*?\[(.+?)\].*?', '\g<1>', sle).split('=')
+                temp_key, temp_value = re.sub(r'.*?\[(.+?)\].*?', r'\g<1>', sle).split('=')
                 keys.append({temp_key: temp_value})
-                sle = re.sub('(.*?\[).+?(\].*?)', f'\g<1>{len(keys) - 1}\g<2>', sle)
+                sle = re.sub(r'(.*?\[).+?(\].*?)', fr'\g<1>{len(keys) - 1}\g<2>', sle)
                 temp_path += sle
 
             if len(temp_non_modified) < len (path_in_question):
@@ -40,7 +40,7 @@ def gnmi_path_generator(path_in_question: list):
                 if len(parts) > 1 and parts[1]:
                     gnmi_path.elem.add(name=parts[1])
 
-            elif re.match('.+?\[\d+?\]', pe_entry):
+            elif re.match(r'.+?\[\d+?\]', pe_entry):
                 element_keys = {}
                 path_info = [re.sub(']', '', en) for en in pe_entry.split('[')]
                 element = path_info.pop(0)


### PR DESCRIPTION
Fixes these deprecation warnings (which are visible when python is launched with -W flag or when run under pytest)
```
../../../venv/pytest/src/pygnmi/pygnmi/path_generator.py:17
  /var/lib/jenkins/venv/pytest/src/pygnmi/pygnmi/path_generator.py:17: DeprecationWarning: invalid escape sequence \[
    if re.match('.*?\[.+?=.+?\].*?', path_in_question):

../../../venv/pytest/src/pygnmi/pygnmi/path_generator.py:18
  /var/lib/jenkins/venv/pytest/src/pygnmi/pygnmi/path_generator.py:18: DeprecationWarning: invalid escape sequence \[
    split_list = re.findall('.*?\[.+?=.+?\].*?', path_in_question)

../../../venv/pytest/src/pygnmi/pygnmi/path_generator.py:22
  /var/lib/jenkins/venv/pytest/src/pygnmi/pygnmi/path_generator.py:22: DeprecationWarning: invalid escape sequence \[
    temp_key, temp_value = re.sub('.*?\[(.+?)\].*?', '\g<1>', sle).split('=')

../../../venv/pytest/src/pygnmi/pygnmi/path_generator.py:22
  /var/lib/jenkins/venv/pytest/src/pygnmi/pygnmi/path_generator.py:22: DeprecationWarning: invalid escape sequence \g
    temp_key, temp_value = re.sub('.*?\[(.+?)\].*?', '\g<1>', sle).split('=')

../../../venv/pytest/src/pygnmi/pygnmi/path_generator.py:24
  /var/lib/jenkins/venv/pytest/src/pygnmi/pygnmi/path_generator.py:24: DeprecationWarning: invalid escape sequence \[
    sle = re.sub('(.*?\[).+?(\].*?)', f'\g<1>{len(keys) - 1}\g<2>', sle)

../../../venv/pytest/src/pygnmi/pygnmi/path_generator.py:24
../../../venv/pytest/src/pygnmi/pygnmi/path_generator.py:24
  /var/lib/jenkins/venv/pytest/src/pygnmi/pygnmi/path_generator.py:24: DeprecationWarning: invalid escape sequence \g
    sle = re.sub('(.*?\[).+?(\].*?)', f'\g<1>{len(keys) - 1}\g<2>', sle)

../../../venv/pytest/src/pygnmi/pygnmi/path_generator.py:36
  /var/lib/jenkins/venv/pytest/src/pygnmi/pygnmi/path_generator.py:36: DeprecationWarning: invalid escape sequence \[
    if re.match('.+?\[\d+?\]', pe_entry):
```