### PR TITLE
Add working support for set and subscribe to cli wrapper pygnmicli.py

### DIFF
--- a/pygnmi/arg_parser.py
+++ b/pygnmi/arg_parser.py
@@ -2,174 +2,110 @@
 #(c)2019-2021, karneliuk.com
 
 # Modules
+import argparse
 import re
-from getpass import getpass
-from .client import logger
-import sys
-
-# Classes
-class NFData(object):
-    """
-    This object stores the prameters related to the specific network element.
-    It includes credentials, IP, port, operation type, path and JSON object, and others.
-    """
-
-    def __init__(self, input_vars, msg):
-        allowed_operations = {'capabilities', 'set', 'get', 'subscribe'}
-
-        self.username = False
-        self.password = False
-        self.targets = None
-        self.insecure = False
-        self.certificate = None
-        self.operation = False
-        self.gnmi_path = None
-        self.to_print = False
-        self.update = None
-        self.replace = None
-
-        ind = 0
-        while ind < len(input_vars):
-            if re.match('^-', input_vars[ind]):
-                if input_vars[ind] == '-u' or input_vars[ind] == '--user':
-                    try:
-                        self.username = str(input_vars[ind + 1])
-                        ind += 2
-
-                    except IndexError:
-                        print(msg['not_enough_arg'])
-                        logger.critical(msg['not_enough_arg'])
-                        sys.exit(3)
-
-                elif input_vars[ind] == '-p' or input_vars[ind] == '--pass':
-                    try:
-                        self.password = str(input_vars[ind + 1])
-                        ind += 2
-
-                    except IndexError:
-                        print(msg['not_enough_arg'])
-                        logger.critical(msg['not_enough_arg'])
-                        sys.exit(3)
-
-                elif input_vars[ind] == '-t' or input_vars[ind] == '--target':
-                    try:
-                        if re.match(r'\[.*\]', input_vars[ind + 1]):
-                            self.targets = re.sub(r'^\[([0-9a-f:]+?)\]:(\d+?)$', r'\g<1> \g<2>', input_vars[ind + 1]).split(' ')
-                            self.targets = (str(self.targets[0]), int(self.targets[1]))
-
-                        else:
-                            self.targets = (str(input_vars[ind + 1].split(':')[0]), int(input_vars[ind + 1].split(':')[1]))
-
-                        ind += 2
-
-                    except IndexError:
-                        print(msg['bad_host'])
-                        logger.error(msg['bad_host'])
-                        sys.exit(2)
-
-                    except ValueError:
-                        print(msg['wrong_data'])
-                        logger.error(msg['wrong_data'])
-                        sys.exit(2)
 
 
-                elif input_vars[ind] == '-o' or input_vars[ind] == '--operation':
-                    try:
-                        self.operation = str(input_vars[ind + 1]).lower()
+def parse_args(msg):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-t", "--target",
+        type=str,
+        required=True,
+        help="Target device connection details in 'host:port' format",
+    )
+    parser.add_argument(
+        "-u", "--user",
+        type=str,
+        required=False,
+        help="Username to use when connecting",
+        dest="username"
+    )
+    parser.add_argument(
+        "-p", "--pass",
+        type=str,
+        required=False,
+        help="Password to use when connecting",
+        dest="password"
+    )
+    parser.add_argument(
+        "-c", "--path_cert", type=str, required=False, help="Path to certificate chain file",
+    )
+    parser.add_argument(
+        "-k", "--path_key", type=str, required=False, help="Path to private key file"
+    )
+    parser.add_argument(
+        "-r", "--path_root", type=str, required=False, help="Path to root CA file"
+    )
+    parser.add_argument(
+        "-O", "--override",
+        type=str,
+        required=False,
+        help="Override the expected server hostname to match certificate name",
+    )
+    parser.add_argument(
+        "-i", "--insecure",
+        action="store_true",
+        default=False,
+        help="Set to disable TLS encryption on the gRPC channel",
+    )
+    parser.add_argument(
+        "-o", "--operation",
+        type=str,
+        required=False,
+        choices=[
+            "get", "set-update", "set-replace", "set-delete",
+            "subscribe-stream", "subscribe-poll", "subscribe-once"
+        ],
+        default="get",
+        help="gNMI Request type",
+    )
+    parser.add_argument(
+        "-x", "--gnmi_path",
+        type=str,
+        required=True,
+        default="", nargs="+",
+        help="gNMI paths of interest in XPath format, space separated"
+    )
+    parser.add_argument(
+        "-d", "--datastore",
+        type=str,
+        required=False,
+        choices=["all", "config", "operational", "state"],
+        default="all", const="all", nargs="?",
+        help="Which datastore to operate on",
+    )
+    parser.add_argument(
+        "-f", "--file",
+        type=str,
+        required=False,
+        help="Path to file containing JSON data to use in a set request",
+    )
+    parser.add_argument(
+        "-D", "--print",
+        action="store_true",
+        default=False,
+        help="Set to enable printing of Protobuf messages to STDOUT",
+    )
 
-                        if self.operation not in allowed_operations:
-                            print(msg['not_allowed_op'])
-                            logger.critical(msg['not_allowed_op'])
-                            sys.exit(2)                            
+    args = parser.parse_args()
 
-                        ind += 2
+    targets = args.target
+    try:
+        if re.match(r'\[.*\]', targets):
+            args.target = re.sub(r'^\[([0-9a-f:]+?)\]:(\d+?)$', r'\g<1> \g<2>', targets).split(' ')
+            args.target = (str(args.target[0]), int(args.target[1]))
+        else:
+            args.target = (str(targets.split(':')[0]), int(targets.split(':')[1]))
+    except IndexError:
+        parser.error(msg['bad_host'])
+    except ValueError:
+        parser.error(msg['wrong_data'])
 
-                    except IndexError:
-                        print(msg['not_enough_arg'])
-                        logger.critical(msg['not_enough_arg'])
-                        sys.exit(3)
+    if args.operation in ("set-update", "set-replace"):
+        if args.file is None:
+            parser.error(f"--file is required when doing a {args.operation} operation")
+        if len(args.gnmi_path) > 1:
+            parser.error(f"Only one path supported when doing a {args.operation} operation")
 
-                elif input_vars[ind] == '-c' or input_vars[ind] == '--cert':
-                    try:
-                        self.certificate = str(input_vars[ind + 1])
-                        ind += 2
-
-                    except IndexError:
-                        print(msg['not_enough_arg'])
-                        logger.critical(msg['not_enough_arg'])
-                        sys.exit(3)
-
-                elif input_vars[ind] == '--insecure':
-                    self.insecure = True
-                    ind += 1
-
-                elif input_vars[ind] == '--print':
-                    self.to_print = True
-                    ind += 1
-
-                elif input_vars[ind] == '--gnmi-path':
-                    try:
-                        paths = input_vars[ind + 1].split(',')
-                        try:
-                            self.gnmi_path = [str(path) for path in paths]
-
-                        except IndexError:
-                            print(msg['bad_host'])
-                            logger.error(msg['bad_host'])
-                            sys.exit(2)
-
-                        except ValueError:
-                            print(msg['wrong_data'])
-                            logger.error(msg['wrong_data'])
-                            sys.exit(2)
-
-                        ind += 2
-
-                    except IndexError:
-                        print(msg['not_enough_arg'])
-                        logger.critical(msg['not_enough_arg'])
-                        sys.exit(3)
-
-                elif input_vars[ind] == '-h' or input_vars[ind] == '--help':
-                    print(msg['help'])
-                    logger.info(f'Help is triggered. The execution is terminated.')
-                    sys.exit(2)
-
-                else:
-                    print(msg['unknown_arg'])
-                    logger.error(msg['unknown_arg'])
-                    sys.exit(2)
-
-            else:
-                print(f'Key {input_vars[ind]} is malformed. It must start with "-" or "--".')
-                sys.exit(2)
-
-        if not self.username:
-            print(msg['not_defined_user'])
-            logger.critical(msg['not_defined_user'])
-            sys.exit(3)
-
-        if not self.password:
-            print(msg['not_defined_pass'])
-            logger.warning(msg['not_defined_pass'])
-            self.password = str(getpass('gRPC password:'))
-
-        if not self.targets:
-            print(msg['not_defined_target'])
-            logger.critical(msg['not_defined_target'])
-            sys.exit(3)
-        
-        if not self.operation:
-            print(msg['not_defined_op'])
-            logger.critical(msg['not_defined_op'])
-            sys.exit(3)
-
-        if not self.gnmi_path and (self.operation == 'get' or self.operation == 'set'):
-            print(msg['not_defined_path'])
-            logger.critical(msg['not_defined_path'])
-            sys.exit(3)
-
-        if self.operation == 'set' and not (self.update or self.gnmi_path or self.replace):
-            print(msg['not_defined_set'])
-            logger.critical(msg['not_defined_set'])
-            sys.exit(3)
+    return args

--- a/pygnmi/artefacts/messages.py
+++ b/pygnmi/artefacts/messages.py
@@ -8,7 +8,7 @@ msg = {
     'not_defined_pass': 'The password is not defined.',
     'not_defined_target': 'There are no hosts provided. The execution is terminated.',
     'not_enough_arg': 'There are not enough arguments.',
-    'wrong_data': 'The argument is provided in thw wrong type (e.g. string instead of integer).',
+    'wrong_data': 'The argument is provided in the wrong type (e.g. string instead of integer).',
     'not_allowed_op': 'The request gNMI operation type is now allowed.',
     'not_defined_op': 'The gNMI operation type is not defined.',
     'not_defined_path': 'The gNMI path is ot defined with Get or Set operation.',


### PR DESCRIPTION
Refactors the argument parser to use the common argparse library, as
well as adding proper support for set and subscribe operations in the
various different modes.

For the set operations, when doing an update or replace, an additional parameter `--file` is expected, that contains valid JSON to push to the device.

Subscribe stream, once and poll (via an interactive prompt) are supported.

I've tried to keep the arguments as close to the original as possible. I've also included support for the additional certificate options (root certificate and keyfile). Below is the help string output with the changes

```
$ ./pygnmicli.py -h
usage: pygnmicli.py [-h] -t TARGET [-u USERNAME] [-p PASSWORD] [-c PATH_CERT] [-k PATH_KEY] [-r PATH_ROOT] [-O OVERRIDE] [-i] [-o {get,set-update,set-replace,set-delete,subscribe-stream,subscribe-poll,subscribe-once}] -x GNMI_PATH [GNMI_PATH ...] [-d [{all,config,operational,state}]] [-f FILE] [-D]

optional arguments:
  -h, --help            show this help message and exit
  -t TARGET, --target TARGET
                        Target device connection details in 'host:port' format
  -u USERNAME, --user USERNAME
                        Username to use when connecting
  -p PASSWORD, --pass PASSWORD
                        Password to use when connecting
  -c PATH_CERT, --path_cert PATH_CERT
                        Path to certificate chain file
  -k PATH_KEY, --path_key PATH_KEY
                        Path to private key file
  -r PATH_ROOT, --path_root PATH_ROOT
                        Path to root CA file
  -O OVERRIDE, --override OVERRIDE
                        Override the expected server hostname to match certificate name
  -i, --insecure        Set to disable TLS encryption on the gRPC channel
  -o {get,set-update,set-replace,set-delete,subscribe-stream,subscribe-poll,subscribe-once}, --operation {get,set-update,set-replace,set-delete,subscribe-stream,subscribe-poll,subscribe-once}
                        gNMI Request type
  -x GNMI_PATH [GNMI_PATH ...], --gnmi_path GNMI_PATH [GNMI_PATH ...]
                        gNMI paths of interest in XPath format, space separated
  -d [{all,config,operational,state}], --datastore [{all,config,operational,state}]
                        Which datastore to operate on
  -f FILE, --file FILE  Path to file containing JSON data to use in a set request
  -D, --print           Set to enable printing of Protobuf messages to STDOUT
```