### PR TITLE
Adding return type in case of gNMI Set Error

### DIFF
--- a/pygnmi/client.py
+++ b/pygnmi/client.py
@@ -588,7 +588,7 @@ class gNMIclient(object):
             print(f"Host: {self.__target_path}\nError: {err.details()}")
             logger.critical(f"GRPC ERROR Host: {self.__target_path}, Error: {err.details()}")
 
-            raise Exception (err)
+            return err
 
         # except:
         #     logger.error(f'Collection of Set information failed is failed.')


### PR DESCRIPTION
Adding return type in case of gNMI Set Error  to parse the error string in the automation
as of now there is no return type. 
This can adds retrun type in case of error . 
Please approve and merge 

test Logs :

> //In case of gNMI Set error  
> 
> `------------------------------------------------
> Host: 10.127.60.177:57400
> Error: gNMI commit-request: operation-failed: Subsystem(7331), Code(9): cerrno 0x4e519200: Slot 1 claimed by Cisco Native config. Hence, Terminal device can't be accepted: Cisco-IOS-XR-terminal-device-cfg:logical-channels/channel[channel-index = '3027']/logical-channel-assignments/logical-channel-assignment[assignment-index = '1']/logical-channel-id
> GRPC ERROR Host: 10.127.60.177:57400, Error: gNMI commit-request: operation-failed: Subsystem(7331), Code(9): cerrno 0x4e519200: Slot 1 claimed by Cisco Native config. Hence, Terminal device can't be accepted: Cisco-IOS-XR-terminal-device-cfg:logical-channels/channel[channel-index = '3027']/logical-channel-assignments/logical-channel-assignment[assignment-index = '1']/logical-channel-id
> 
> In [5]: test
> Out[5]: 
> <_InactiveRpcError of RPC that terminated with:
> 	status = StatusCode.INTERNAL
> 	details = "gNMI commit-request: operation-failed: Subsystem(7331), Code(9): cerrno 0x4e519200: Slot 1 claimed by Cisco Native config. Hence, Terminal device can't be accepted: Cisco-IOS-XR-terminal-device-cfg:logical-channels/channel[channel-index = '3027']/logical-channel-assignments/logical-channel-assignment[assignment-index = '1']/logical-channel-id"
> 	debug_error_string = "{"created":"@1644434044.116483064","description":"Error received from peer ipv4:10.127.60.177:57400","file":"src/core/lib/surface/call.cc","file_line":1074,"grpc_message":"gNMI commit-request: operation-failed: Subsystem(7331), Code(9): cerrno 0x4e519200: Slot 1 claimed by Cisco Native config. Hence, Terminal device can't be accepted: Cisco-IOS-XR-terminal-device-cfg:logical-channels/channel[channel-index = '3027']/logical-channel-assignments/logical-channel-assignment[assignment-index = '1']/logical-channel-id","grpc_status":13}"
> >
> 
> In [6]: type(test)
> Out[6]: grpc._channel._InactiveRpcError
> 
> In [7]: test.result
> Out[7]: 
> <bound method _InactiveRpcError.result of <_InactiveRpcError of RPC that terminated with:
> 	status = StatusCode.INTERNAL
> 	details = "gNMI commit-request: operation-failed: Subsystem(7331), Code(9): cerrno 0x4e519200: Slot 1 claimed by Cisco Native config. Hence, Terminal device can't be accepted: Cisco-IOS-XR-terminal-device-cfg:logical-channels/channel[channel-index = '3027']/logical-channel-assignments/logical-channel-assignment[assignment-index = '1']/logical-channel-id"
> 	debug_error_string = "{"created":"@1644434044.116483064","description":"Error received from peer ipv4:10.127.60.177:57400","file":"src/core/lib/surface/call.cc","file_line":1074,"grpc_message":"gNMI commit-request: operation-failed: Subsystem(7331), Code(9): cerrno 0x4e519200: Slot 1 claimed by Cisco Native config. Hence, Terminal device can't be accepted: Cisco-IOS-XR-terminal-device-cfg:logical-channels/channel[channel-index = '3027']/logical-channel-assignments/logical-channel-assignment[assignment-index = '1']/logical-channel-id","grpc_status":13}"
> >>
> In [14]: test.debug_error_string()
> Out[14]: '{"created":"@1644434044.116483064","description":"Error received from peer ipv4:10.127.60.177:57400","file":"src/core/lib/surface/call.cc","file_line":1074,"grpc_message":"gNMI commit-request: operation-failed: Subsystem(7331), Code(9): cerrno 0x4e519200: Slot 1 claimed by Cisco Native config. Hence, Terminal device can\'t be accepted: Cisco-IOS-XR-terminal-device-cfg:logical-channels/channel[channel-index = \'3027\']/logical-channel-assignments/logical-channel-assignment[assignment-index = \'1\']/logical-channel-id","grpc_status":13}'
> 
> In [15]: type(test.debug_error_string())
> Out[15]: str
> 
> In case of pass its returning a dict 
> 
> gNMI response:
> ------------------------------------------------
> response {
>   path {
>     origin: "openconfig-terminal-device"
>     elem {
>       name: "terminal-device"
>     }
>   }
>   message {
>   }
>   op: UPDATE
> }
> message {
> }
> timestamp: 1644434261191158985
> 
> ------------------------------------------------
> 
> In [17]: test
> Out[17]: 
> {'timestamp': 1644434261191158985,
>  'prefix': None,
>  'response': [{'path': 'terminal-device', 'op': 'UPDATE'}]}
> 
> In [18]: type(test)
> Out[18]: dict
> 

`