### PR TITLE
Same exception behavior for `set()` and `get()` + `set_with_retry()` fix

### DIFF
--- a/pygnmi/client.py
+++ b/pygnmi/client.py
@@ -459,10 +459,9 @@ class gNMIclient(object):
             logger.critical(f"GRPC ERROR Host: {self.__target_path}, Error: {err.details()}")
             raise gNMIException(f"GRPC ERROR Host: {self.__target_path}, Error: {err.details()}", err)
 
-        # except:
-        #     logger.error(f'Collection of Get information failed is failed.')
-
-            return None
+        except Exception as e:
+            logger.error('Collection of Get information failed: %s.', e)
+            raise gNMIException(f'Collection of Get information failed: {e}', e)
 
     def set(self, delete: list = None, replace: list = None,
             update: list = None, encoding: str = 'json',
@@ -649,8 +648,10 @@ class gNMIclient(object):
 
         except grpc._channel._InactiveRpcError as err:
             logger.critical(f"GRPC ERROR Host: {self.__target_path}, Error: {err.details()}")
-
-            return err
+            raise gNMIException(f"GRPC ERROR Host: {self.__target_path}, Error: {err.details()}", err)
+        except Exception as e:
+            logger.error("Set failed: %s", e)
+            raise gNMIException(f"Set failed: {e}", e)
 
 
     def set_with_retry(self, delete: list = None, replace: list = None, update: list = None, encoding: str = 'json', retry_delay: int = 3):


### PR DESCRIPTION
Heyhey, I wrote this before the release of 0.8.0, i.e. before you commented out the `except` in `get()`, so I guess there's a decision to make! In my proposal we wrap all exceptions inside the `gNMIException`, which is more the behavior of pre-0.8.0. If you want though I can also remove the `except Exception` handlers in `get()` and `set()`, so we only handle the grpc internal exceptions. What do you think?

Also, see commit messages for details. This is a breaking change of the error handling behavior of `set()` as exceptions are raised and not returned. On the other hand this seems to be the way things once were, as `set_with_retry()` clearly expects `set()` to raise a grpc exception.