### PR TITLE
Correct wrong operation name in exception text

### DIFF
--- a/pygnmi/client.py
+++ b/pygnmi/client.py
@@ -588,7 +588,7 @@ class gNMIclient(object):
 
             else:
                 logger.error(f'The provided input for Set message (update operation) is not list.')
-                raise gNMIException('The provided input for Set message (replace operation) is not list.')
+                raise gNMIException('The provided input for Set message (update operation) is not list.')
 
         try:
             # Adding collection of data for diff before the change


### PR DESCRIPTION
Exception said that replace was in a wrong format but actually update
was (same as the log.error() message).