### PR TITLE
0.8.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,9 +86,16 @@ Contributors
 Dev Log
 =======
 
+Release **0.8.6**:
+
+- Fixed minor issue with establishing ``insecure`` channel.
+- Fixed bug with inabillity to specify ``prefix`` in Subscribe messages for ``subscribe2()`` method.
+- **Important**: It is recommended to use method ``subscribe2()`` instead of ``subscribe()`` for building telemetry collectors with ``pygnmi`` as this method is further developed and throroughle tested. The method ``subscribe()`` will be deprecated in future releases.
+- Functionality ``qos`` is now properly supported in ``subscribe2()`` method.
+
 Release **0.8.5**:
 
-- Fixed some issues with telemetry represenation with ``pygnmicli``.
+- Fixed some issues with telemetry representation with ``pygnmicli``.
 
 Release **0.8.4**:
 
@@ -394,7 +401,7 @@ Release **0.1.0**:
 
 (c)2020-2022, karneliuk.com
 
-.. |version| image:: https://img.shields.io/static/v1?label=latest&message=v0.8.4&color=success
+.. |version| image:: https://img.shields.io/static/v1?label=latest&message=v0.8.6&color=success
 .. _version: https://pypi.org/project/pygnmi/
 .. |tag| image:: https://img.shields.io/static/v1?label=status&message=stable&color=success
 .. _tag: https://pypi.org/project/pygnmi/

--- a/pygnmi/__init__.py
+++ b/pygnmi/__init__.py
@@ -2,4 +2,4 @@
 pyGNMI module to manage network devices with gNMI
 (c)2020-2022, Karneliuk
 """
-__version__ = "0.8.5"
+__version__ = "0.8.6"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst', encoding="utf-8") as fh:
 setup(
   name='pygnmi',
   packages=['pygnmi', 'pygnmi.spec.v080', 'pygnmi.artefacts'],
-  version='0.8.5',
+  version='0.8.6',
   license='bsd-3-clause',
   description='Pure Python gNMI client to manage network functions and collect telemetry.',
   long_description=long_description,
@@ -14,7 +14,7 @@ setup(
   author='Anton Karneliuk',
   author_email='anton@karneliuk.com',
   url='https://github.com/akarneliuk/pygnmi',
-  download_url='https://github.com/akarneliuk/pygnmi/archive/v0.8.5.tar.gz',
+  download_url='https://github.com/akarneliuk/pygnmi/archive/v0.8.6.tar.gz',
   keywords=['gnmi', 'automation', 'grpc', 'network'],
   install_requires=[
           'grpcio',

--- a/tests/messages.py
+++ b/tests/messages.py
@@ -44,7 +44,10 @@ test_telemetry_dict_once = {
                                     'sample_interval': 10000000000,
                                     'heartbeat_interval': 30000000000
                                 }
-                            ], 
+                            ],
+                            'qos': {
+                                'marking': 32
+                            },
                             'use_aliases': False,
                             'mode': 'once',
                             'encoding': 'proto'


### PR DESCRIPTION
- Fixed minor issue with establishing ``insecure`` channel.
- Fixed bug with inabillity to specify ``prefix`` in Subscribe messages for ``subscribe2()`` method.
- **Important**: It is recommended to use method ``subscribe2()`` instead of ``subscribe()`` for building telemetry collectors with ``pygnmi`` as this method is further developed and throroughle tested. The method ``subscribe()`` will be deprecated in future releases.
- Functionality ``qos`` is now properly supported in ``subscribe2()`` method.