### PR TITLE
0.8.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,7 @@ Release **0.8.8**:
 
 - Added new argument ``-e / --encoding`` to ``pygnmicli`` to specify the encoding, which overrides the default one. Fix for `Issue 58 <https://github.com/akarneliuk/pygnmi/issues/58>`_.
 - Fixed minor bug with encoding handling inside ``get()`` and ``subscribe2()`` methods.
+- Simplified the code.
 
 Release **0.8.7**:
 

--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,11 @@ Contributors
 Dev Log
 =======
 
+Release **0.8.8**:
+
+- Added new argument ``-e / --encoding`` to ``pygnmicli`` to specify the encoding, which overrides the default one. Fix for `Issue 58 <https://github.com/akarneliuk/pygnmi/issues/58>`_.
+- Fixed minor bug with encoding handling inside ``get()`` and ``subscribe2()`` methods.
+
 Release **0.8.7**:
 
 - Fixed bug, when returned ``json_val`` or ``json_ietf_val`` is not processed correctly if the value is empty string.  Fix for `Issue 58 <https://github.com/akarneliuk/pygnmi/issues/58>`_.

--- a/pygnmi/__init__.py
+++ b/pygnmi/__init__.py
@@ -2,4 +2,4 @@
 pyGNMI module to manage network devices with gNMI
 (c)2020-2022, Karneliuk
 """
-__version__ = "0.8.7"
+__version__ = "0.8.8"

--- a/pygnmi/arg_parser.py
+++ b/pygnmi/arg_parser.py
@@ -89,6 +89,14 @@ def parse_args(msg):
         help="gNMI Request type",
     )
     parser.add_argument(
+        "-e", "--encoding",
+        type=str,
+        required=False,
+        choices=["json", "bytes", "proto", "ascii", "json_ietf"],
+        default="json",
+        help="Specif the encoding in the gNMI RPC (subject to be supported by the network device",
+    )
+    parser.add_argument(
         "-x", "--gnmi-path",
         type=str,
         required=False,

--- a/pygnmi/client.py
+++ b/pygnmi/client.py
@@ -355,7 +355,14 @@ class gNMIclient(object):
             logger.error('The GetRequst data type is not within the defined range. Using default type \'all\'.')
 
         # Set Protobuf value for encoding
-        pb_encoding = 4
+        if self.__capabilities and 'supported_encodings' in self.__capabilities:
+            if 'json' in self.__capabilities['supported_encodings']:
+                pb_encoding = 0
+            elif 'json_ietf' in self.__capabilities['supported_encodings']:
+                pb_encoding = 4
+        else:
+            pb_encoding = 4
+
         if encoding in encoding_set:
             if encoding.lower() == 'json':
                 pb_encoding = 0
@@ -389,12 +396,6 @@ class gNMIclient(object):
         except Exception as e:
             logger.error('Conversion of gNMI paths to the Protobuf format failed')
             raise gNMIException('Conversion of gNMI paths to the Protobuf format failed', e)
-
-        if self.__capabilities and 'supported_encodings' in self.__capabilities:
-            if 'json' in self.__capabilities['supported_encodings']:
-                pb_encoding = 0
-            elif 'json_ietf' in self.__capabilities['supported_encodings']:
-                pb_encoding = 4
 
         try:
             gnmi_message_request = GetRequest(prefix=protobuf_prefix, path=protobuf_paths,
@@ -766,13 +767,13 @@ class gNMIclient(object):
 
         # Create message for eveyrhting besides subscriptions
         request = SubscriptionList(prefix=gnmi_path_generator(subscribe['prefix'], target),
-                            use_aliases=subscribe['use_aliases'],
-                            qos=subscribe['qos'],
-                            mode=subscribe_mode,
-                            allow_aggregation=subscribe['allow_aggregation'],
-                            use_models=subscribe['use_models'],
-                            encoding=Encoding.Value(subscribe['encoding'].upper()),
-                            updates_only=subscribe['updates_only'])
+                                   use_aliases=subscribe['use_aliases'],
+                                   qos=subscribe['qos'],
+                                   mode=subscribe_mode,
+                                   allow_aggregation=subscribe['allow_aggregation'],
+                                   use_models=subscribe['use_models'],
+                                   encoding=Encoding.Value(subscribe['encoding'].upper()),
+                                   updates_only=subscribe['updates_only'])
 
         # subscription
         if 'subscription' not in subscribe or not subscribe['subscription']:

--- a/scripts/pygnmicli
+++ b/scripts/pygnmicli
@@ -54,7 +54,9 @@ def main():
 
         elif args.operation == 'get':
             print(f'Doing {args.operation} request to {args.target}...')
-            result = GC.get(path=args.gnmi_path, datatype=args.datastore, encoding='json',
+            result = GC.get(path=args.gnmi_path,
+                            datatype=args.datastore,
+                            encoding=args.encoding,
                             target=args.gnmi_path_target)
 
         elif args.operation.startswith('set'):
@@ -70,7 +72,7 @@ def main():
                     data = f.read()
                 jdata = json.loads(data)
                 kwargs[mode] = [(args.gnmi_path[0], jdata)]
-            result = GC.set(encoding="json_ietf", target=args.gnmi_path_target, **kwargs)
+            result = GC.set(encoding=args.encoding, target=args.gnmi_path_target, **kwargs)
 
         elif args.operation.startswith('subscribe'):
             mode = args.operation.split("-")[1]
@@ -85,7 +87,7 @@ def main():
                 'subscription': subscription_list,
                 'use_aliases': False,
                 'mode': mode,
-                'encoding': 'json'
+                'encoding': args.encoding
             }
 
             # Set up extensions

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst', encoding="utf-8") as fh:
 setup(
   name='pygnmi',
   packages=['pygnmi', 'pygnmi.spec.v080', 'pygnmi.artefacts'],
-  version='0.8.7',
+  version='0.8.8',
   license='bsd-3-clause',
   description='Pure Python gNMI client to manage network functions and collect telemetry.',
   long_description=long_description,
@@ -14,7 +14,7 @@ setup(
   author='Anton Karneliuk',
   author_email='anton@karneliuk.com',
   url='https://github.com/akarneliuk/pygnmi',
-  download_url='https://github.com/akarneliuk/pygnmi/archive/v0.8.7.tar.gz',
+  download_url='https://github.com/akarneliuk/pygnmi/archive/v0.8.8.tar.gz',
   keywords=['gnmi', 'automation', 'grpc', 'network'],
   install_requires=[
           'grpcio',


### PR DESCRIPTION
- Added new argument ``-e / --encoding`` to ``pygnmicli`` to specify the encoding, which overrides the default one. Fix for `Issue 58 <https://github.com/akarneliuk/pygnmi/issues/58>`_.
- Fixed minor bug with encoding handling inside ``get()`` and ``subscribe2()`` methods.
- Simplified the code.