### PR TITLE
0.8.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,12 @@ Contributors
 Dev Log
 =======
 
+Release **0.8.9**:
+
+- Default value for ``encoding`` everywhere is set to ``None``.
+- Method ``capabilities()`` now is called as part of ``connect()`` to collect supported encoding as part of session establishing.
+- If ``encoding`` is not specified by user, then it is auto-set based on the list collected via ``capabilites()`` with ``json`` having the first priority follwed by ``json_ietf``.
+
 Release **0.8.8**:
 
 - Added new argument ``-e / --encoding`` to ``pygnmicli`` to specify the encoding, which overrides the default one. Fix for `Issue 58 <https://github.com/akarneliuk/pygnmi/issues/58>`_.
@@ -411,7 +417,7 @@ Release **0.1.0**:
 
 (c)2020-2022, karneliuk.com
 
-.. |version| image:: https://img.shields.io/static/v1?label=latest&message=v0.8.7&color=success
+.. |version| image:: https://img.shields.io/static/v1?label=latest&message=v0.8.9&color=success
 .. _version: https://pypi.org/project/pygnmi/
 .. |tag| image:: https://img.shields.io/static/v1?label=status&message=stable&color=success
 .. _tag: https://pypi.org/project/pygnmi/

--- a/pygnmi/__init__.py
+++ b/pygnmi/__init__.py
@@ -2,4 +2,4 @@
 pyGNMI module to manage network devices with gNMI
 (c)2020-2022, Karneliuk
 """
-__version__ = "0.8.8"
+__version__ = "0.8.9"

--- a/pygnmi/arg_parser.py
+++ b/pygnmi/arg_parser.py
@@ -157,6 +157,12 @@ def parse_args(msg):
         required=False,
         help="Specify the snapshit time for the GNMI history",
     )
+    parser.add_argument(
+        "--gnmi-timeout",
+        type=int,
+        required=False,
+        help="Specify the timeout for GNMI session",
+    )
 
     args = parser.parse_args()
 

--- a/scripts/pygnmicli
+++ b/scripts/pygnmicli
@@ -40,7 +40,7 @@ def main():
         target=args.target, username=args.username, password=args.password, token=args.token,
         path_cert=args.path_cert, path_key=args.path_key, path_root=args.path_root,
         override=args.override, insecure=args.insecure, debug=args.debug,
-        show_diff=args.compare, skip_verify=args.skip_verify
+        show_diff=args.compare, skip_verify=args.skip_verify, gnmi_timeout=args.gnmi_timeout
     ) as GC:
 
         result = None

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst', encoding="utf-8") as fh:
 setup(
   name='pygnmi',
   packages=['pygnmi', 'pygnmi.spec.v080', 'pygnmi.artefacts'],
-  version='0.8.8',
+  version='0.8.9',
   license='bsd-3-clause',
   description='Pure Python gNMI client to manage network functions and collect telemetry.',
   long_description=long_description,
@@ -14,7 +14,7 @@ setup(
   author='Anton Karneliuk',
   author_email='anton@karneliuk.com',
   url='https://github.com/akarneliuk/pygnmi',
-  download_url='https://github.com/akarneliuk/pygnmi/archive/v0.8.8.tar.gz',
+  download_url='https://github.com/akarneliuk/pygnmi/archive/v0.8.9.tar.gz',
   keywords=['gnmi', 'automation', 'grpc', 'network'],
   install_requires=[
           'grpcio',


### PR DESCRIPTION
- Default value for ``encoding`` everywhere is set to ``None``.
- Method ``capabilities()`` now is called as part of ``connect()`` to collect supported encoding as part of session establishing.
- If ``encoding`` is not specified by user, then it is auto-set based on the list collected via ``capabilites()`` with ``json`` having the first priority follwed by ``json_ietf``.
