### PR TITLE
Support keys with no value in gnmi_path_generator

### DIFF
--- a/pygnmi/create_gnmi_path.py
+++ b/pygnmi/create_gnmi_path.py
@@ -35,8 +35,8 @@ def gnmi_path_generator(path_in_question: str,
 
     # Subtracting all the keys from the elements and storing them separately
     if path_in_question:
-        if re.match(r'.*?\[.+?=.+?\].*?', path_in_question):
-            split_list = re.findall(r'.*?\[.+?=.+?\].*?', path_in_question)
+        if re.match(r'.*?\[.+?=.*?\].*?', path_in_question):
+            split_list = re.findall(r'.*?\[.+?=.*?\].*?', path_in_question)
 
             for sle in split_list:
                 temp_non_modified += sle

--- a/tests/test_00_create_xpath.py
+++ b/tests/test_00_create_xpath.py
@@ -108,6 +108,14 @@ test_paths = [
                 PathElem(name="interface",
                          key={"name": "Loopback111"})])),
 
+    # multiple keys, one with no value. From ietf-alarms.yang https://datatracker.ietf.org/doc/rfc8632/
+    ("alarms/alarm-list/alarm[alarm-type-id=test-alarm][alarm-type-qualifier=]/is-cleared",
+     Path(elem=[PathElem(name="alarms"),
+                PathElem(name="alarm-list"),
+                PathElem(name="alarm",
+                         key={"alarm-type-id": "test-alarm", "alarm-type-qualifier": ""}),
+                PathElem(name="is-cleared")])),
+
 ]
 
 


### PR DESCRIPTION
This is valid where there are multiple keys and not all are mandatory, as is the case in ietf-alarms.yang for alarm-type-qualifier


This was previously accepted prior to the rework of the gnmi_path_generator function. I've added a unit-test along with the change, and ensured existing tests still pass.

For a bit more context on this specific case, since I originally thought it wasn't valid to have an empty key, someone else had the same question and outlines the specific part of the model: https://discuss.tail-f.com/t/how-to-access-list-element-on-the-key-which-is-empty/3602
