### PR TITLE
Stop using root logger in client.py

### DIFF
--- a/pygnmi/client.py
+++ b/pygnmi/client.py
@@ -266,10 +266,10 @@ class gNMIclient(object):
             for p in ["json", "json_ietf", "bytes", "proto", "ascii"]:
                 if p in self.__supported_encodings:
                     self.__encoding = p
-                    logging.info(f"Selected encoding '{p}' based on capabilities")
+                    logger.info(f"Selected encoding '{p}' based on capabilities")
                     break
         else:
-            logging.warning(f"Unable to detect supported encodings, defaulting to '{self.__encoding}'")
+            logger.warning(f"Unable to detect supported encodings, defaulting to '{self.__encoding}'")
 
         return self
 


### PR DESCRIPTION
I noticed the root logger being used, presumably unintentionally:
```
INFO     pygnmi.client:client.py:302 Collecting Capabilities...
INFO     pygnmi.client:client.py:342 Collection of Capabilities is successfull
INFO     root:client.py:269 Selected encoding 'json_ietf' based on capabilities 