### PR TITLE
adding bytes_val and leaflist_val with string_val parsing

### DIFF
--- a/pygnmi/client.py
+++ b/pygnmi/client.py
@@ -1266,7 +1266,16 @@ def telemetryParser(in_message=None, debug: bool = False):
                         update_container.update({"val": update_msg.val.proto_bytes})
 
                     elif update_msg.val.HasField("bytes_val"):
-                        update_container.update({"val": update_msg.val.bytes_val})
+                        val_binary = ''.join(format(byte, '08b') for byte in update_msg.val.bytes_val)
+                        val_decimal = struct.unpack("f", struct.pack("I", int(val_binary, 2)))[0]
+                        update_container.update({'val': val_decimal})
+                    
+                    elif update_msg.val.HasField('leaflist_val'):
+                        val_leaflist = update_msg.val
+                        element_str = ""
+                        for element in val_leaflist.leaflist_val.element:
+                            element_str += element
+                        update_container.update({'val': element_str})
 
                 response["update"]["update"].append(update_container)
 


### PR DESCRIPTION
Hi @akarneliuk 

Finally had time to work on committing the bytes_val, but also added a recent find that leaflist_val is not being processed either.
For bytes_val, it is just converting the ieeefloat32 value correctly, and for leaflist_val, it looks like so:

MainThread_2024-03-07 10:19:23,121_gnmi_subscribe_INFO_telemetry_entry={'update': {'update': [{'path': 'system/processes/process[pid=5983]/state/args', 'val': '-C /etc/dnsmasq.conf -h -H /etc/hosts --pid-file=/var/run/dnsmasq.pid'}], 'timestamp': 1709602406601003300}, 'sync_response': True}