### PR TITLE
Properly handle TypedValue as leaflist_val

### DIFF
--- a/pygnmi/client.py
+++ b/pygnmi/client.py
@@ -1109,6 +1109,12 @@ class _Subscriber:
                     self._updates.put(update)
             except Exception as error:
                 self.error = error
+                
+                # The connection was terminated by the server. This is generally okay and
+                # shouldn't raise an exception.
+                if isinstance(error, grpc._channel._MultiThreadedRendezvous) and error.code() == grpc.StatusCode.CANCELLED:
+                    return
+                
                 raise error
 
         self._subscribe_thread = threading.Thread(target=enqueue_updates)


### PR DESCRIPTION
Previously, only str values were supported as the value of a leaflist_val. This extends the code to also support TypedValues with json and json_ietf formats, for both subscriptions and get. 